### PR TITLE
 Robustify event handling for IDB transactions

### DIFF
--- a/lib/lawndart.dart
+++ b/lib/lawndart.dart
@@ -40,7 +40,7 @@ following: local storage, indexed db, and websql.
 See the `example/` directory for more sample code.
 
 */
-library lawndart;
+library;
 
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';

--- a/lib/src/_map_store.dart
+++ b/lib/src/_map_store.dart
@@ -12,7 +12,7 @@
 //See the License for the specific language governing permissions and
 //limitations under the License.
 
-part of lawndart;
+part of '../lawndart.dart';
 
 abstract class _MapStore extends Store {
   Map<String, String> storage = {};

--- a/lib/src/indexeddb_store.dart
+++ b/lib/src/indexeddb_store.dart
@@ -12,7 +12,7 @@
 //See the License for the specific language governing permissions and
 //limitations under the License.
 
-part of lawndart;
+part of '../lawndart.dart';
 
 abstract final class _IDBEventStreamProviders {
   static const EventStreamProvider<Event> successEvent = EventStreamProvider('success');

--- a/lib/src/local_storage_store.dart
+++ b/lib/src/local_storage_store.dart
@@ -12,7 +12,7 @@
 //See the License for the specific language governing permissions and
 //limitations under the License.
 
-part of lawndart;
+part of '../lawndart.dart';
 
 /**
  * Wraps the local storage API and exposes it as a [Store].

--- a/lib/src/memory_store.dart
+++ b/lib/src/memory_store.dart
@@ -12,7 +12,7 @@
 //See the License for the specific language governing permissions and
 //limitations under the License.
 
-part of lawndart;
+part of '../lawndart.dart';
 
 class MemoryStore extends _MapStore {
   MemoryStore._() : super._();


### PR DESCRIPTION
Along with the actual fixes, there is also a small fix to use modern `library`/`part of` directives, instead of the older, named style.